### PR TITLE
Refactor config merging to avoid attribute collision warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Dnsmasq Local Cookbook CHANGELOG
 Unreleased
 ----------
 - Ensure the APT cache is up to date before installing
+- Refactor config merging to avoid attribute collision warnings
 
 v0.1.0 (2016-05-06)
 -------------------

--- a/libraries/provider_dnsmasq_local_config.rb
+++ b/libraries/provider_dnsmasq_local_config.rb
@@ -45,8 +45,11 @@ class Chef
       #
       action :create do
         directory '/etc/dnsmasq.d'
+        merged_config = new_resource.config.merge(
+          new_resource.state.select { |k, _| k != :config }
+        )
         file '/etc/dnsmasq.d/dns.conf' do
-          content config_body_for(new_resource.config)
+          content config_body_for(merged_config)
         end
       end
 

--- a/libraries/resource_dnsmasq_local_config.rb
+++ b/libraries/resource_dnsmasq_local_config.rb
@@ -67,7 +67,8 @@ class Chef
       #
       def method_missing(method_symbol, *args, &block)
         if block.nil? && args.length == 1
-          config[method_symbol] = args[0]
+          self.class.attribute method_symbol, kind_of: args[0].class
+          send(method_symbol, args[0]) unless args[0].nil?
         else
           super
         end

--- a/spec/resources/dnsmasq_local/ubuntu/14_04_spec.rb
+++ b/spec/resources/dnsmasq_local/ubuntu/14_04_spec.rb
@@ -16,14 +16,18 @@ describe 'resource_dnsmasq_local::ubuntu::14_04' do
 
     shared_examples_for 'any attribute set' do
       it 'creates the dnsmasq_local_config' do
-        expected = { interface: '',
-                     cache_size: 0,
-                     no_hosts: true,
-                     bind_interfaces: true,
-                     proxy_dnssec: true,
-                     query_port: 0 }.merge(config.to_h).sort.to_h
+        expected = {
+          config: {
+            interface: '',
+            cache_size: 0,
+            no_hosts: true,
+            bind_interfaces: true,
+            proxy_dnssec: true,
+            query_port: 0
+          }
+        }.merge(config.to_h)
         expect(chef_run).to create_dnsmasq_local_config('default')
-          .with(config: expected)
+          .with(expected)
         expect(chef_run.dnsmasq_local_config('default'))
           .to notify('dnsmasq_local_service[default]').to(:restart)
       end

--- a/spec/resources/dnsmasq_local/ubuntu/14_04_spec.rb
+++ b/spec/resources/dnsmasq_local/ubuntu/14_04_spec.rb
@@ -1,18 +1,21 @@
 require_relative '../../../spec_helper'
 
 describe 'resource_dnsmasq_local::ubuntu::14_04' do
-  let(:config) { nil }
+  let(:name) { 'default' }
+  %i(config action).each { |p| let(p) { nil } }
   let(:runner) do
     ChefSpec::SoloRunner.new(
       step_into: 'dnsmasq_local', platform: 'ubuntu', version: '14.04'
     ) do |node|
-      node.set['dnsmasq_local']['config'] = config unless config.nil?
+      %i(name config action).each do |p|
+        node.set['resource_dnsmasq_local_test'][p] = send(p) unless send(p).nil?
+      end
     end
   end
-  let(:converge) { runner.converge("resource_dnsmasq_local_test::#{action}") }
+  let(:converge) { runner.converge('resource_dnsmasq_local_test') }
 
   context 'the default action (:create)' do
-    let(:action) { :default }
+    let(:action) { nil }
 
     shared_examples_for 'any attribute set' do
       it 'creates the dnsmasq_local_config' do

--- a/spec/resources/dnsmasq_local_app/ubuntu/14_04_spec.rb
+++ b/spec/resources/dnsmasq_local_app/ubuntu/14_04_spec.rb
@@ -1,18 +1,25 @@
 require_relative '../../../spec_helper'
 
 describe 'resource_dnsmasq_local_app::ubuntu::14_04' do
-  let(:config) { nil }
+  let(:name) { 'default' }
+  let(:action) { nil }
   let(:runner) do
-    ChefSpec::SoloRunner.new(step_into: 'dnsmasq_local_app',
-                             platform: 'ubuntu',
-                             version: '14.04')
+    ChefSpec::SoloRunner.new(
+      step_into: 'dnsmasq_local_app', platform: 'ubuntu', version: '14.04'
+    ) do |node|
+      %i(name action).each do |p|
+        unless send(p).nil?
+          node.set['resource_dnsmasq_local_app_test'][p] = send(p)
+        end
+      end
+    end
   end
   let(:converge) do
-    runner.converge("resource_dnsmasq_local_app_test::#{action}")
+    runner.converge('resource_dnsmasq_local_app_test')
   end
 
   context 'the default action (:install)' do
-    let(:action) { :default }
+    let(:action) { nil }
     cached(:chef_run) { converge }
 
     it 'ensures the APT cache is up to date' do

--- a/spec/resources/dnsmasq_local_config/ubuntu/14_04_spec.rb
+++ b/spec/resources/dnsmasq_local_config/ubuntu/14_04_spec.rb
@@ -1,26 +1,25 @@
 require_relative '../../../spec_helper'
 
 describe 'resource_dnsmasq_local_config::ubuntu::14_04' do
+  let(:name) { 'default' }
+  %i(config properties action).each { |p| let(p) { nil } }
   let(:override_config) { nil }
   let(:merge_configs) { nil }
   let(:runner) do
     ChefSpec::SoloRunner.new(
       step_into: 'dnsmasq_local_config', platform: 'ubuntu', version: '14.04'
     ) do |node|
-      unless override_config.nil?
-        node.set['dnsmasq_local']['override_config'] = override_config
-      end
-      unless merge_configs.nil?
-        node.set['dnsmasq_local']['merge_configs'] = merge_configs
+      %i(name config properties action).each do |p|
+        unless send(p).nil?
+          node.set['resource_dnsmasq_local_config_test'][p] = send(p)
+        end
       end
     end
   end
-  let(:converge) do
-    runner.converge("resource_dnsmasq_local_config_test::#{action}")
-  end
+  let(:converge) { runner.converge('resource_dnsmasq_local_config_test') }
 
   context 'the default action (:create)' do
-    let(:action) { :default }
+    let(:action) { nil }
 
     shared_examples_for 'any attributes' do
       it 'creates the dnsmasq.d directory' do
@@ -29,8 +28,8 @@ describe 'resource_dnsmasq_local_config::ubuntu::14_04' do
     end
 
     context 'the default attributes' do
-      let(:override_config) { nil }
-      let(:merge_configs) { nil }
+      let(:config) { nil }
+      let(:properties) { nil }
       cached(:chef_run) { converge }
 
       it_behaves_like 'any attributes'
@@ -50,7 +49,7 @@ describe 'resource_dnsmasq_local_config::ubuntu::14_04' do
     end
 
     context 'a default config override' do
-      let(:override_config) do
+      let(:config) do
         {
           interface: 'docker0',
           no_hosts: false,
@@ -59,7 +58,7 @@ describe 'resource_dnsmasq_local_config::ubuntu::14_04' do
           other_bool: false
         }
       end
-      let(:merge_configs) { nil }
+      let(:properties) { nil }
       cached(:chef_run) { converge }
 
       it_behaves_like 'any attributes'
@@ -76,8 +75,8 @@ describe 'resource_dnsmasq_local_config::ubuntu::14_04' do
     end
 
     context 'some extra configs to merge in with the default' do
-      let(:override_config) { nil }
-      let(:merge_configs) do
+      let(:config) { nil }
+      let(:properties) do
         {
           interface: 'docker0',
           no_hosts: false,
@@ -106,8 +105,8 @@ describe 'resource_dnsmasq_local_config::ubuntu::14_04' do
     end
 
     context 'an invalid config attribute' do
-      let(:override_config) { { example: :bad } }
-      let(:merge_configs) { nil }
+      let(:config) { { example: :bad } }
+      let(:properties) { nil }
       cached(:chef_run) { converge }
 
       it 'raises an error' do

--- a/spec/resources/dnsmasq_local_service/ubuntu/14_04_spec.rb
+++ b/spec/resources/dnsmasq_local_service/ubuntu/14_04_spec.rb
@@ -1,18 +1,23 @@
 require_relative '../../../spec_helper'
 
 describe 'resource_dnsmasq_local_service::ubuntu::14_04' do
-  let(:config) { nil }
+  let(:name) { 'default' }
+  let(:action) { nil }
   let(:runner) do
-    ChefSpec::SoloRunner.new(step_into: 'dnsmasq_local_service',
-                             platform: 'ubuntu',
-                             version: '14.04')
+    ChefSpec::SoloRunner.new(
+      step_into: 'dnsmasq_local_service', platform: 'ubuntu', version: '14.04'
+    ) do |node|
+      %i(name action).each do |p|
+        unless send(p).nil?
+          node.set['resource_dnsmasq_local_service_test'][p] = send(p)
+        end
+      end
+    end
   end
-  let(:converge) do
-    runner.converge("resource_dnsmasq_local_service_test::#{action}")
-  end
+  let(:converge) { runner.converge('resource_dnsmasq_local_service_test') }
 
   context 'the default action ([:enable, :start])' do
-    let(:action) { :default }
+    let(:action) { nil }
     cached(:chef_run) { converge }
 
     it 'enables the dnsmasq service' do

--- a/spec/support/cookbooks/resource_dnsmasq_local_app_test/recipes/default.rb
+++ b/spec/support/cookbooks/resource_dnsmasq_local_app_test/recipes/default.rb
@@ -1,3 +1,7 @@
 # Encoding: UTF-8
 
-dnsmasq_local_app 'default'
+attrs = node['resource_dnsmasq_local_app_test']
+
+dnsmasq_local_app attrs['name'] do
+  action attrs['action'] unless attrs['action'].nil?
+end

--- a/spec/support/cookbooks/resource_dnsmasq_local_app_test/recipes/remove.rb
+++ b/spec/support/cookbooks/resource_dnsmasq_local_app_test/recipes/remove.rb
@@ -1,5 +1,0 @@
-# Encoding: UTF-8
-
-dnsmasq_local_app 'default' do
-  action :remove
-end

--- a/spec/support/cookbooks/resource_dnsmasq_local_config_test/recipes/default.rb
+++ b/spec/support/cookbooks/resource_dnsmasq_local_config_test/recipes/default.rb
@@ -1,9 +1,9 @@
 # Encoding: UTF-8
 
-override_config = node['dnsmasq_local']['override_config']
-merge_configs = node['dnsmasq_local']['merge_configs']
+attrs = node['resource_dnsmasq_local_config_test']
 
-dnsmasq_local_config 'default' do
-  config override_config unless override_config.nil?
-  merge_configs.to_h.each { |k, v| send(k, v) }
+dnsmasq_local_config attrs['name'] do
+  config attrs['config'] unless attrs['config'].nil?
+  attrs['properties'].to_h.each { |k, v| send(k, v) }
+  action attrs['action'] unless attrs['action'].nil?
 end

--- a/spec/support/cookbooks/resource_dnsmasq_local_config_test/recipes/remove.rb
+++ b/spec/support/cookbooks/resource_dnsmasq_local_config_test/recipes/remove.rb
@@ -1,5 +1,0 @@
-# Encoding: UTF-8
-
-dnsmasq_local_config 'default' do
-  action :remove
-end

--- a/spec/support/cookbooks/resource_dnsmasq_local_service_test/recipes/default.rb
+++ b/spec/support/cookbooks/resource_dnsmasq_local_service_test/recipes/default.rb
@@ -1,3 +1,7 @@
 # Encoding: UTF-8
 
-dnsmasq_local_service 'default'
+attrs = node['resource_dnsmasq_local_service_test']
+
+dnsmasq_local_service attrs['name'] do
+  action attrs['action'] unless attrs['action'].nil?
+end

--- a/spec/support/cookbooks/resource_dnsmasq_local_service_test/recipes/disable.rb
+++ b/spec/support/cookbooks/resource_dnsmasq_local_service_test/recipes/disable.rb
@@ -1,5 +1,0 @@
-# Encoding: UTF-8
-
-dnsmasq_local_service 'default' do
-  action :disable
-end

--- a/spec/support/cookbooks/resource_dnsmasq_local_service_test/recipes/enable.rb
+++ b/spec/support/cookbooks/resource_dnsmasq_local_service_test/recipes/enable.rb
@@ -1,5 +1,0 @@
-# Encoding: UTF-8
-
-dnsmasq_local_service 'default' do
-  action :enable
-end

--- a/spec/support/cookbooks/resource_dnsmasq_local_service_test/recipes/start.rb
+++ b/spec/support/cookbooks/resource_dnsmasq_local_service_test/recipes/start.rb
@@ -1,5 +1,0 @@
-# Encoding: UTF-8
-
-dnsmasq_local_service 'default' do
-  action :start
-end

--- a/spec/support/cookbooks/resource_dnsmasq_local_service_test/recipes/stop.rb
+++ b/spec/support/cookbooks/resource_dnsmasq_local_service_test/recipes/stop.rb
@@ -1,5 +1,0 @@
-# Encoding: UTF-8
-
-dnsmasq_local_service 'default' do
-  action :stop
-end

--- a/spec/support/cookbooks/resource_dnsmasq_local_test/recipes/default.rb
+++ b/spec/support/cookbooks/resource_dnsmasq_local_test/recipes/default.rb
@@ -1,5 +1,8 @@
 # Encoding: UTF-8
 
-dnsmasq_local 'default' do
-  config node['dnsmasq_local']['config']
+attrs = node['resource_dnsmasq_local_test']
+
+dnsmasq_local attrs['name'] do
+  config attrs['config'] unless attrs['config'].nil?
+  action attrs['action'] unless attrs['action'].nil?
 end

--- a/spec/support/cookbooks/resource_dnsmasq_local_test/recipes/remove.rb
+++ b/spec/support/cookbooks/resource_dnsmasq_local_test/recipes/remove.rb
@@ -1,5 +1,0 @@
-# Encoding: UTF-8
-
-dnsmasq_local 'default' do
-  action :remove
-end


### PR DESCRIPTION
Chef was throwing warnings because 'config' is an attribute on both the
'dnsmasq_local' and 'dnsmasq_local_config' resources. Normally we'd get
more specific by just writing 'new_resource.config' instead, but that
won't work here due to the legacy Chef 11 support.

This warning can then bubble up into more serious issues, as it has been
with causing new builds of some of our other cookbooks to fail.