### PR TITLE
Fix Chef 11 compatibility + support config items that can have >1 value

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -25,5 +25,7 @@ suites:
       dnsmasq_local:
         config:
           cache_size: 64
-          server: 8.8.8.8
+          server:
+            - 8.8.8.8
+            - 8.8.4.4
           address: /example.biz/127.0.0.1

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,4 +18,12 @@ suites:
   - name: default
     run_list:
       - recipe[dnsmasq-local_test]
+  - name: custom
+    run_list:
+      - recipe[dnsmasq-local_test]
     attributes:
+      dnsmasq_local:
+        config:
+          cache_size: 64
+          server: 8.8.8.8
+          address: /example.biz/127.0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Dnsmasq Local Cookbook CHANGELOG
 Unreleased
 ----------
 - Fix custom config properties/attributes under Chef 11
+- Support arrays for config attributes with >1 value (e.g. "server")
 
 v0.2.0 (2016-05-18)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Dnsmasq Local Cookbook CHANGELOG
 
 Unreleased
 ----------
+- Fix custom config properties/attributes under Chef 11
 
 v0.2.0 (2016-05-18)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Dnsmasq Local Cookbook CHANGELOG
 ================================
 
+Unreleased
+----------
+
 v0.2.0 (2016-05-18)
 -------------------
 - Ensure the APT cache is up to date before installing

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Syntax:
     dnsmasq_local_config 'default' do
         config { cache_size: 100 }
         no_hosts false
+        server %w(8.8.8.8 8.8.4.4)
         action :create
     end
 
@@ -139,7 +140,8 @@ Attributes:
   it.
 
 \*\* Any unrecognized attribute that is passed in will be assumed to be a
-  correct Dnsmasq setting and rendered out to its config.
+  correct Dnsmasq setting and rendered out to its config. These attributes'
+values can be `true`, `false`, integers, strings, or arrays.
 
 ***dnsmasq_local_service***
 

--- a/libraries/resource_dnsmasq_local_config.rb
+++ b/libraries/resource_dnsmasq_local_config.rb
@@ -27,8 +27,11 @@ class Chef
     # @author Jonathan Hartman <jonathan.hartman@socrata.com>
     class DnsmasqLocalConfig < LWRPBase
       self.resource_name = :dnsmasq_local_config
+
       actions :create, :remove
       default_action :create
+
+      state_attrs :config
 
       #
       # Set up a default config attribute hash that can overridden in its
@@ -68,10 +71,23 @@ class Chef
       def method_missing(method_symbol, *args, &block)
         if block.nil? && args.length == 1
           self.class.attribute method_symbol, kind_of: args[0].class
+          add_state_attr(method_symbol)
           send(method_symbol, args[0]) unless args[0].nil?
         else
           super
         end
+      end
+
+      #
+      # Add a newly-declared attribute into the list of desired state
+      # attributes to account for the fact that Chef 12 defaults this to true
+      # while 11 defaults it to false.
+      #
+      # @param attr [Symbol] the new attribute to add to the list of state ones
+      #
+      def add_state_attr(attr)
+        new_attrs = (self.class.state_attrs << attr).uniq
+        self.class.state_attrs(*new_attrs)
       end
     end
   end

--- a/libraries/resource_dnsmasq_local_config.rb
+++ b/libraries/resource_dnsmasq_local_config.rb
@@ -25,7 +25,7 @@ class Chef
     # A Chef resource for generating Dnsmasq configs.
     #
     # @author Jonathan Hartman <jonathan.hartman@socrata.com>
-    class DnsmasqLocalConfig < LWRPBase
+    class DnsmasqLocalConfig < LWRPBase # rubocop:disable Style/Documentation
       self.resource_name = :dnsmasq_local_config
 
       actions :create, :remove
@@ -91,4 +91,6 @@ class Chef
       end
     end
   end
-end
+end unless defined?(Chef::Resource::DnsmasqLocalConfig)
+# Don't let this class be reloaded or strange things happen to the custom
+# properties we've loaded in via `method_missing`.

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ maintainer_email 'jonathan.hartman@socrata.com'
 license 'apache2'
 description 'Configures a local-only dnsmasq'
 long_description 'Configures a local-only dnsmasq'
-version '0.2.0'
+version '0.2.1'
 
 if respond_to?(:source_url)
   source_url 'https://github.com/socrata-cookbooks/dnsmasq-local'

--- a/spec/resources/dnsmasq_local_config/ubuntu/14_04_spec.rb
+++ b/spec/resources/dnsmasq_local_config/ubuntu/14_04_spec.rb
@@ -81,6 +81,7 @@ describe 'resource_dnsmasq_local_config::ubuntu::14_04' do
           interface: 'docker0',
           no_hosts: false,
           example: 'elpmaxe',
+          server: %w(8.8.8.8 8.8.4.4),
           bool: true,
           other_bool: false
         }
@@ -98,6 +99,8 @@ describe 'resource_dnsmasq_local_config::ubuntu::14_04' do
           interface=docker0
           proxy-dnssec
           query-port=0
+          server=8.8.8.8
+          server=8.8.4.4
         EOH
         expect(chef_run).to create_file('/etc/dnsmasq.d/dns.conf')
           .with(content: expected)

--- a/test/integration/custom/serverspec/localhost/app_spec.rb
+++ b/test/integration/custom/serverspec/localhost/app_spec.rb
@@ -1,0 +1,11 @@
+# Encoding: UTF-8
+
+require_relative '../spec_helper'
+
+describe 'dnsmasq-local::custom::app' do
+  describe package('dnsmasq') do
+    it 'is installed' do
+      expect(subject).to be_installed
+    end
+  end
+end

--- a/test/integration/custom/serverspec/localhost/config_spec.rb
+++ b/test/integration/custom/serverspec/localhost/config_spec.rb
@@ -16,8 +16,9 @@ describe 'dnsmasq-local::custom::config' do
       expect(subject.content).to match(/^query-port=0$/)
     end
 
-    it 'is pointed at a Google nameserver' do
+    it 'is pointed at Google nameservers' do
       expect(subject.content).to match(/^server=8\.8\.8\.8$/)
+      expect(subject.content).to match(/^server=8\.8\.4\.4$/)
     end
 
     it 'has a custom DNS entry for example.biz' do

--- a/test/integration/custom/serverspec/localhost/config_spec.rb
+++ b/test/integration/custom/serverspec/localhost/config_spec.rb
@@ -1,0 +1,27 @@
+# Encoding: UTF-8
+
+require_relative '../spec_helper'
+
+describe 'dnsmasq-local::custom::config' do
+  describe file('/etc/dnsmasq.d/dns.conf') do
+    it 'is listening on the local interface only' do
+      expect(subject.content).to match(/^interface=$/)
+    end
+
+    it 'is caching lookup results' do
+      expect(subject.content).to match(/^cache-size=64$/)
+    end
+
+    it 'is sticking to the system ephemeral port range' do
+      expect(subject.content).to match(/^query-port=0$/)
+    end
+
+    it 'is pointed at a Google nameserver' do
+      expect(subject.content).to match(/^server=8\.8\.8\.8$/)
+    end
+
+    it 'has a custom DNS entry for example.biz' do
+      expect(subject.content).to match(%r{^address=/example.biz/127\.0\.0\.1$})
+    end
+  end
+end

--- a/test/integration/custom/serverspec/localhost/service_spec.rb
+++ b/test/integration/custom/serverspec/localhost/service_spec.rb
@@ -1,0 +1,21 @@
+# Encoding: UTF-8
+
+require_relative '../spec_helper'
+
+describe 'dnsmasq-local::custom::service' do
+  describe service('dnsmasq') do
+    it 'is enabled' do
+      expect(subject).to be_enabled
+    end
+
+    it 'is running' do
+      expect(subject).to be_running
+    end
+  end
+
+  describe file('/run/resolvconf/resolv.conf') do
+    it 'is using localhost as the nameserver' do
+      expect(subject.content).to match(/^nameserver 127\.0\.0\.1$/)
+    end
+  end
+end

--- a/test/integration/custom/serverspec/spec_helper.rb
+++ b/test/integration/custom/serverspec/spec_helper.rb
@@ -1,0 +1,10 @@
+# Encoding: UTF-8
+
+require 'serverspec'
+
+if RUBY_PLATFORM =~ /mswin|mingw32|windows/
+  set :os, family: 'windows'
+  set :backend, :cmd
+else
+  set :backend, :exec
+end


### PR DESCRIPTION
The different behavior we were seeing in 11 vs 12 was due to the fact that every property member of a resource is either a part of the "desired state" or not. In 12 the default is true, in 11 it was false. So, when we set:

```
default['dnsmasq_local']['config']['interface'] = 'docker0'
```

and rendered a config file by iterating over the desired state properties, this setting would never make it out of Chef 11.

This also adds support for settings that can have more than one value, e.g.:

```
server=8.8.8.8
server=8.8.4.4
```

by allowing array properties in addition to strings, integers, and booleans.