### PR TITLE
Support hashes as config properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Dnsmasq Local Cookbook CHANGELOG
 
 Unreleased
 ----------
+- Support hashes as config properties
 
 v0.4.0 (2016-06-24)
 -------------------

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ attributes with an underscore (e.g. `cache_size`).
 Any Dnsmasq setting that is a boolean key with no value (e.g. `proxy_dnssec`)
 can be set to true or false to be enabled or disabled, respectively.
 
+Any setting that can have multiple entries can be set as either an array
+(where all entries will be rendered in the config) or a hash (where entries
+set to false will not be rendered).
+
     default['dnsmasq_local']['config'] = {}
 
 Any key+value can be set under this namespace and it will be merged into the

--- a/libraries/provider_dnsmasq_local_config.rb
+++ b/libraries/provider_dnsmasq_local_config.rb
@@ -91,14 +91,12 @@ class Chef
       #
       def config_for(key, val)
         case val
-        when TrueClass, FalseClass
-          key.to_s.tr('_', '-') if val
-        when String, Fixnum
-          "#{key.to_s.tr('_', '-')}=#{val}"
-        when Array
-          val.map { |v| config_for(key, v) }.join("\n")
-        else
-          raise(Exceptions::ValidationFailed, "Invalid: '#{key}' => '#{val}'")
+        when TrueClass, FalseClass then key.to_s.tr('_', '-') if val
+        when String, Fixnum then "#{key.to_s.tr('_', '-')}=#{val}"
+        when Array then val.map { |v| config_for(key, v) }.join("\n")
+        when Hash then config_for(key, val.keys.select { |k| val[k] })
+        else raise(Exceptions::ValidationFailed,
+                   "Invalid: '#{key}' => '#{val}'")
         end
       end
     end

--- a/libraries/resource_dnsmasq_local_config.rb
+++ b/libraries/resource_dnsmasq_local_config.rb
@@ -69,13 +69,22 @@ class Chef
       # (see Chef::Resource#method_missing)
       #
       def method_missing(method_symbol, *args, &block)
-        if block.nil? && args.length == 1
+        if block.nil? && args.length == 1 && !method_symbol.match(/^to_/)
           self.class.attribute method_symbol, kind_of: args[0].class
           add_state_attr(method_symbol)
           send(method_symbol, args[0]) unless args[0].nil?
         else
           super
         end
+      end
+
+      #
+      # Respond to missing methods.
+      #
+      # (see Object#respond_to_missing?)
+      #
+      def respond_to_missing?(method_symbol, *args, &block)
+        block.nil? && args.length == 1 && !method_symbol.match(/^to_/) || super
       end
 
       #

--- a/libraries/resource_dnsmasq_local_service.rb
+++ b/libraries/resource_dnsmasq_local_service.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 #
 
+require 'chef/resource/service'
 require 'chef/resource/lwrp_base'
 
 class Chef
@@ -50,13 +51,22 @@ class Chef
       # (see Chef::Resource#method_missing)
       #
       def method_missing(method_symbol, *args, &block)
-        if block.nil? && args.length == 1
+        if block.nil? && args.length == 1 && !method_symbol.match(/^to_/)
           self.class.attribute method_symbol, kind_of: args[0].class
           add_state_attr(method_symbol)
           send(method_symbol, args[0]) unless args[0].nil?
         else
           super
         end
+      end
+
+      #
+      # Respond to missing methods.
+      #
+      # (see Object#respond_to_missing?)
+      #
+      def respond_to_missing?(method_symbol, *args, &block)
+        block.nil? && args.length == 1 && !method_symbol.match(/^to_/) || super
       end
 
       #

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -8,7 +8,7 @@ describe 'dnsmasq-local::default' do
   let(:runner) do
     ChefSpec::SoloRunner.new(platform) do |node|
       %i(config environment).each do |a|
-        node.set['dnsmasq_local'][a] = send(a) unless send(a).nil?
+        node.normal['dnsmasq_local'][a] = send(a) unless send(a).nil?
       end
     end
   end

--- a/spec/resources/dnsmasq_local_app_spec.rb
+++ b/spec/resources/dnsmasq_local_app_spec.rb
@@ -9,7 +9,9 @@ describe 'dnsmasq_local_app' do
       step_into: resource, platform: platform, version: platform_version
     ) do |node|
       %i(resource name action).each do |p|
-        node.set['dnsmasq_local_resource_test'][p] = send(p) unless send(p).nil?
+        unless send(p).nil?
+          node.default['dnsmasq_local_resource_test'][p] = send(p)
+        end
       end
     end
   end

--- a/spec/resources/dnsmasq_local_config_spec.rb
+++ b/spec/resources/dnsmasq_local_config_spec.rb
@@ -13,7 +13,9 @@ describe 'dnsmasq_local_config' do
       step_into: resource, platform: platform, version: platform_version
     ) do |node|
       %i(resource name config properties action).each do |p|
-        node.set['dnsmasq_local_resource_test'][p] = send(p) unless send(p).nil?
+        unless send(p).nil?
+          node.default['dnsmasq_local_resource_test'][p] = send(p)
+        end
       end
     end
   end
@@ -93,6 +95,7 @@ describe 'dnsmasq_local_config' do
               no_hosts: false,
               example: 'elpmaxe',
               server: %w(8.8.8.8 8.8.4.4),
+              ahash: { key1: true, key2: false, key3: true },
               bool: true,
               other_bool: false
             }
@@ -105,6 +108,8 @@ describe 'dnsmasq_local_config' do
             expected = <<-EOH.gsub(/^ {14}/, '').strip
               # This file is managed by Chef.
               # Any changes to it will be overwritten.
+              ahash=key1
+              ahash=key3
               bind-interfaces
               bool
               cache-size=0

--- a/spec/resources/dnsmasq_local_service_spec.rb
+++ b/spec/resources/dnsmasq_local_service_spec.rb
@@ -11,7 +11,9 @@ describe 'dnsmasq_local_service' do
       step_into: resource, platform: platform, version: platform_version
     ) do |node|
       %i(resource name environment properties action).each do |p|
-        node.set['dnsmasq_local_resource_test'][p] = send(p) unless send(p).nil?
+        unless send(p).nil?
+          node.default['dnsmasq_local_resource_test'][p] = send(p)
+        end
       end
     end
   end

--- a/spec/resources/dnsmasq_local_spec.rb
+++ b/spec/resources/dnsmasq_local_spec.rb
@@ -11,7 +11,9 @@ describe 'dnsmasq_local' do
       step_into: resource, platform: platform, version: platform_version
     ) do |node|
       %i(resource name config environment action).each do |p|
-        node.set['dnsmasq_local_resource_test'][p] = send(p) unless send(p).nil?
+        unless send(p).nil?
+          node.default['dnsmasq_local_resource_test'][p] = send(p)
+        end
       end
     end
   end


### PR DESCRIPTION
This will allow multi-value config settings to be overridden. For
example:

```
default['dnsmasq_local']['config']['server']['8.8.8.8'] = true

normal['dnsmasq_local']['config']['server']['8.8.8.8'] = false
```