### PR TITLE
Remove 'proxy-dnssec' as a default setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ underscore:
 Any option that is a boolean with no value can be set to true or false to be
 enabled or disabled:
 
-    default['dnsmasq_local']['config']['proxy_dnssec'] = false
+    default['dnsmasq_local']['config']['proxy_dnssec'] = true
 
 Any option that can have multiple entries can be set as either an array
 (where all entries will be rendered in the config) or a hash (where entries
@@ -154,7 +154,6 @@ Attributes:
 | cache_size      | 0          | Disable caching
 | no_hosts        | true       | Do not DNSify `/etc/hosts`            |
 | bind_interfaces | true       | Bind only to listening interfaces     |
-| proxy_dnssec    | true       | Proxy DNSSEC, when available          |
 | query_port      | 0          | Use a static, ephemeral return port   |
 | \*\*            | `nil`      | Varies                                |
 | action          | `:create`  | Action(s) to perform                  |

--- a/libraries/resource_dnsmasq_local_config.rb
+++ b/libraries/resource_dnsmasq_local_config.rb
@@ -42,7 +42,6 @@ class Chef
       #   * Disable caching
       #   * Do not create DNS for entries in /etc/hosts
       #   * Bind only to the interfaces being listened on
-      #   * Proxy DNSSEC, when available
       #   * Use a static reply port instead of randomly generating one for each
       #     query. This does pose a security risk for publicly-exposed servers
       #     (Don't run this there!), but ensures the return port will always
@@ -59,7 +58,6 @@ class Chef
                   cache_size: 0,
                   no_hosts: true,
                   bind_interfaces: true,
-                  proxy_dnssec: true,
                   query_port: 0
                 }
 

--- a/spec/resources/dnsmasq_local.rb
+++ b/spec/resources/dnsmasq_local.rb
@@ -20,7 +20,6 @@ shared_context 'resources::dnsmasq_local' do
               cache_size: 0,
               no_hosts: true,
               bind_interfaces: true,
-              proxy_dnssec: true,
               query_port: 0
             }
           }.merge(config.to_h)

--- a/spec/resources/dnsmasq_local_config.rb
+++ b/spec/resources/dnsmasq_local_config.rb
@@ -39,7 +39,6 @@ shared_context 'resources::dnsmasq_local_config' do
             cache-size=0
             interface=
             no-hosts
-            proxy-dnssec
             query-port=0
           EOH
           expect(chef_run).to create_file('/etc/dnsmasq.d/dns.conf')
@@ -96,7 +95,6 @@ shared_context 'resources::dnsmasq_local_config' do
             cache-size=0
             example=elpmaxe
             interface=docker0
-            proxy-dnssec
             query-port=0
             server=8.8.8.8
             server=8.8.4.4
@@ -166,7 +164,6 @@ shared_context 'resources::dnsmasq_local_config' do
             cache-size=0
             example=elpmaxe
             interface=docker0
-            proxy-dnssec
             query-port=0
             server=8.8.8.8
             server=8.8.4.4

--- a/test/fixtures/cookbooks/dnsmasq-local_test/attributes/default.rb
+++ b/test/fixtures/cookbooks/dnsmasq-local_test/attributes/default.rb
@@ -1,6 +1,0 @@
-# encoding: utf-8
-# frozen_string_literal: true
-
-if node['platform_family'] == 'rhel' && node['platform_version'].to_i < 7
-  default['dnsmasq_local']['config']['proxy_dnssec'] = false
-end


### PR DESCRIPTION
Sounds like leaving it off is the more sensible default.