### PR TITLE
Guard against setting DNSMASQ_OPTS as an environment variable

### DIFF
--- a/libraries/resource_dnsmasq_local_service.rb
+++ b/libraries/resource_dnsmasq_local_service.rb
@@ -57,9 +57,17 @@ class Chef # rubocop:disable Style/MultilineIfModifier
       # Supporting populating the `/etc/default/dnsmasq` file with any other
       # arbitrary environment variables. It is up to the user to ensure the
       # variables are valid and used by the version of Dnsmasq on their
-      # platform.
+      # platform. The only environment variable that cannot be set here is
+      # DNSMASQ_OPTS, as that is controlled by the options property above.
       #
-      property :environment, Hash, default: {}
+      property :environment,
+               Hash,
+               default: {},
+               callbacks: {
+                 'Invalid environment variable: DNSMASQ_OPTS' => lambda { |v|
+                   !v.keys.map(&:to_s).include?('DNSMASQ_OPTS')
+                 }
+               }
 
       #
       # Allow individual properties to be fed in and merged with the default

--- a/spec/resources/dnsmasq_local_service.rb
+++ b/spec/resources/dnsmasq_local_service.rb
@@ -61,6 +61,10 @@ shared_context 'resources::dnsmasq_local_service' do
     let(:environment) { { PANTS: 'no', SHORTS: 'yes' } }
   end
 
+  shared_context 'an invalid environment property' do
+    let(:environment) { { PANTS: 'no', SHORTS: 'yes', DNSMASQ_OPTS: '--bad' } }
+  end
+
   shared_context 'the NetworkManager service running' do
     let(:network_manager_running?) { true }
   end
@@ -154,6 +158,14 @@ shared_context 'resources::dnsmasq_local_service' do
           EOH
           expect(chef_run).to create_file('/etc/default/dnsmasq')
             .with(content: expected)
+        end
+      end
+
+      context 'an invalid environment property' do
+        include_context description
+
+        it 'raises an error' do
+          expect { chef_run }.to raise_error(Chef::Exceptions::ValidationFailed)
         end
       end
 


### PR DESCRIPTION
This part of the env is populated by the service resource's options
and wildcard properties.