### PR TITLE
Run app, config, and service resources in the parent run context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Dnsmasq Local Cookbook CHANGELOG
 
 Unreleased
 ----------
+- Run app, config, and service resources in the root run context
 
 v2.0.0 (2017-05-18)
 -------------------

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Requirements
 
 This cookbook currently supports both Debian-based and RHEL-based platforms.
 
-It now requires Chef 12.5+.
+It now requires Chef 12.10+, or Chef 12.1+ and the compat_resource cookbook.
 
 Usage
 =====

--- a/libraries/resource_dnsmasq_local_app_rhel_rpm.rb
+++ b/libraries/resource_dnsmasq_local_app_rhel_rpm.rb
@@ -38,7 +38,7 @@ class Chef
       #
       action :remove do
         rpm_package 'dnsmasq' do
-          options '--noscripts' if node['platform_version'].to_i < 7
+          options '--noscripts'
           action :remove
         end
       end

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ license 'Apache-2.0'
 description 'Configures a local-only dnsmasq'
 long_description 'Configures a local-only dnsmasq'
 version '2.0.1'
-chef_version '>= 12'
+chef_version '>= 12.1'
 
 source_url 'https://github.com/socrata-cookbooks/dnsmasq-local'
 issues_url 'https://github.com/socrata-cookbooks/dnsmasq-local/issues'

--- a/test/fixtures/cookbooks/dnsmasq-local_test/recipes/_prep.rb
+++ b/test/fixtures/cookbooks/dnsmasq-local_test/recipes/_prep.rb
@@ -1,0 +1,26 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+execute 'apt-get update' if node['platform_family'] == 'debian'
+
+if %w[docker lxc].include?(node['virtualization']['system'])
+  case node['platform_family']
+  when 'debian'
+    # Fake out the Docker build and its immutable resolv.conf.
+    directory '/var/lib/resolvconf'
+    file '/var/lib/resolvconf/linkified'
+    package 'apt-utils'
+    package 'resolvconf'
+
+    service 'resolvconf' do
+      action %i[enable start]
+    end
+  when 'rhel'
+    if node['platform_version'].to_i >= 7
+      package 'NetworkManager'
+      service 'NetworkManager' do
+        action %i[enable start]
+      end
+    end
+  end
+end

--- a/test/fixtures/cookbooks/dnsmasq-local_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/dnsmasq-local_test/recipes/default.rb
@@ -1,28 +1,5 @@
 # encoding: utf-8
 # frozen_string_literal: true
 
-execute 'apt-get update' if node['platform_family'] == 'debian'
-
-if %w[docker lxc].include?(node['virtualization']['system'])
-  case node['platform_family']
-  when 'debian'
-    # Fake out the Docker build and its immutable resolv.conf.
-    directory '/var/lib/resolvconf'
-    file '/var/lib/resolvconf/linkified'
-    package 'apt-utils'
-    package 'resolvconf'
-
-    service 'resolvconf' do
-      action %i[enable start]
-    end
-  when 'rhel'
-    if node['platform_version'].to_i >= 7
-      package 'NetworkManager'
-      service 'NetworkManager' do
-        action %i[enable start]
-      end
-    end
-  end
-end
-
+include_recipe '::_prep'
 include_recipe 'dnsmasq-local'

--- a/test/fixtures/cookbooks/dnsmasq-local_test/recipes/remove.rb
+++ b/test/fixtures/cookbooks/dnsmasq-local_test/recipes/remove.rb
@@ -3,9 +3,9 @@
 
 include_recipe '::_prep'
 
-dnsmasq_local_config '_default'
-dnsmasq_local_app '_default'
-dnsmasq_local_service '_default'
+dnsmasq_local_config 'default'
+dnsmasq_local_app 'default'
+dnsmasq_local_service 'default'
 
 dnsmasq_local 'default' do
   action :remove

--- a/test/fixtures/cookbooks/dnsmasq-local_test/recipes/remove.rb
+++ b/test/fixtures/cookbooks/dnsmasq-local_test/recipes/remove.rb
@@ -1,7 +1,11 @@
 # encoding: utf-8
 # frozen_string_literal: true
 
-include_recipe '::default'
+include_recipe '::_prep'
+
+dnsmasq_local_config '_default'
+dnsmasq_local_app '_default'
+dnsmasq_local_service '_default'
 
 dnsmasq_local 'default' do
   action :remove


### PR DESCRIPTION
This way, the restart notifications take action at the end of the Chef run
instead of at the end of the dnsmasq_local resource's child run context.