### PR TITLE
Remove 'rvm: system' from the TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-rvm: system
 
 branches:
   only:
@@ -54,7 +53,7 @@ jobs:
         - git remote set-url origin git@github.com:socrata-cookbooks/dnsmasq-local
       deploy:
         provider: script
-        script: rvm use system do chef exec stove --username socrata --key .travis/client.pem
+        script: chef exec stove --username socrata --key .travis/client.pem
         skip_cleanup: true
 
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Dnsmasq-Local Cookbook CHANGELOG
 
-This file is used to list changes made in each version of the dnsmasq-local
-cookbook.
+This file is used to list changes made in each version of the dnsmasq-local cookbook.
 
-## 2.3.0 (2018-05-03)
+## 2.2.3 (2019-01-28)
+
+- Remove 'rvm: system' from the TravisCI config
+
+## 2.2.2 (2018-05-03)
 
 - Inherit test configs from a central repo where possible
 - Disable systemd-resolved on Systemd platforms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the dnsmasq-local cook
 ## 2.2.3 (2019-01-28)
 
 - Remove 'rvm: system' from the TravisCI config
+- Resolve new style offenses
 
 ## 2.2.2 (2018-05-03)
 

--- a/libraries/resource/dnsmasq_local_service.rb
+++ b/libraries/resource/dnsmasq_local_service.rb
@@ -197,6 +197,7 @@ class Chef # rubocop:disable Style/MultilineIfModifier
       #
       def environment_string(env)
         return nil if env.empty?
+
         env.map { |k, v| "#{k}='#{v}'" }.join("\n")
       end
     end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'sysadmin@socrata.com'
 license 'Apache-2.0'
 description 'Configures a local-only dnsmasq'
 long_description 'Configures a local-only dnsmasq'
-version '2.2.2'
+version '2.2.3'
 chef_version '>= 12.1'
 
 source_url 'https://github.com/socrata-cookbooks/dnsmasq-local'

--- a/spec/resources.rb
+++ b/spec/resources.rb
@@ -11,10 +11,12 @@ shared_context 'resources' do
     ) do |node|
       %i[resource name action].each do |p|
         next if send(p).nil?
+
         node.default['resource_test'][p] = send(p)
       end
       properties.each do |k, v|
         next if v.nil?
+
         node.default['resource_test']['properties'][k] = v
       end
     end


### PR DESCRIPTION
We originally did this because RVM's Ruby and Chef-DK's Ruby were interfering
with each other, but now Travis has a 'gem install bundler' step that's failing
because the travis user doesn't have write permissions on the system Ruby.